### PR TITLE
declare multiprocess compatible, to avoid perf-killing CPOWs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,6 @@
     "fullName": "meta-q-override",
     "id": "jid1-7OsjI9sxTAYQNg",
     "description": "Warn before quitting Firefox.",
-    "permissions": {"private-browsing": true}
+    "permissions": {"private-browsing": true},
+    "multiprocessCompatible": "true"
 }


### PR DESCRIPTION
Without this, nightly will give perf warnings and show high CPOW usage in `about:performance`
